### PR TITLE
Dev rx tx support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.cproject
+.project
+.settings/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,22 @@
 cmake_minimum_required(VERSION 2.8.4)
 
+set(CPACK_PACKAGE_VERSION 0.1.1)
+
 # Configure project.
-project(enyx-net-tools)
+set(CPACK_GENERATOR "TGZ")
+set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY 0)
+set(CPACK_PACKAGE_NAME "enyx-net-tools")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY
+    "Enyx networking tools")
+set(CPACK_PACKAGE_CONTACT "Support <support@enyx.com>")
+set(CPACK_PACKAGE_VENDOR "enyx")
+set(PACKAGE_URL "http://www.enyx.com")
+set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}")
+set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION /usr/lib64/pkgconfig)
+
+include(GNUInstallDirs)
+
+project(${CPACK_PACKAGE_NAME})
 
 find_package(Threads REQUIRED)
 set(Boost_NO_BOOST_CMAKE ON)
@@ -20,3 +35,6 @@ include_directories(${Boost_INCLUDE_DIR})
 link_directories(${Boost_LIBRARY_DIR})
 
 add_subdirectory(src)
+
+include(CPack)
+cpack_add_component(enyx-net-tools REQUIRED)

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -149,6 +149,10 @@ Application::on_receive(std::size_t bytes_transferred,
         verify(bytes_transferred);
         statistics_.received_bytes_count += bytes_transferred;
 
+        if (configuration_.direction == Configuration::RX)
+            statistics_.receive_duration = pt::microsec_clock::universal_time()
+                                           - statistics_.start_date;
+
         std::size_t size = slice_remaining_size - bytes_transferred;
         if (statistics_.received_bytes_count < configuration_.size)
             async_receive(size);

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -61,8 +61,10 @@ Application::Application(const Configuration & configuration)
 
     std::cout << configuration_ << std::endl;
 
-    async_receive();
-    async_send();
+    if (configuration.direction != Configuration::TX)
+        async_receive();
+    if (configuration.direction != Configuration::RX)
+        async_send();
 }
 
 void
@@ -265,7 +267,12 @@ Application::on_send(std::size_t bytes_transferred,
                                            statistics_.start_date;
 
             if (configuration_.shutdown_policy == Configuration::SEND_COMPLETE)
-                socket_.shutdown_send();
+            {
+                if (configuration_.direction == Configuration::TX)
+                    finish();
+                else
+                    socket_.shutdown_send();
+            }
         }
     }
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,3 +20,9 @@ add_executable(nx-iperf
 target_link_libraries(nx-iperf
     ${Boost_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT})
+
+install(TARGETS
+        nx-iperf
+    DESTINATION
+        ${CMAKE_INSTALL_BINDIR}
+    COMPONENT tools)

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -94,6 +94,49 @@ operator<<(std::ostream & out, const Configuration::Mode & mode)
     }
 }
 
+std::istream &
+operator>>(std::istream & in, Configuration::Direction & direction)
+{
+    std::istream::sentry sentry(in);
+
+    if (sentry)
+    {
+        std::string s;
+        in >> s;
+
+        if (s == "tx")
+            direction = Configuration::TX;
+        else if (s == "rx")
+            direction = Configuration::RX;
+        else if (s == "both")
+            direction = Configuration::BOTH;
+        else
+            throw std::runtime_error("Unexpected verification mode");
+    }
+
+    return in;
+}
+
+std::ostream &
+operator<<(std::ostream & out, const Configuration::Direction & direction)
+{
+    std::ostream::sentry sentry(out);
+
+    if (! sentry)
+        return out;
+
+    switch (direction)
+    {
+    default:
+    case Configuration::RX:
+        return out << "tx";
+    case Configuration::TX:
+        return out << "tx";
+    case Configuration::BOTH:
+        return out << "both";
+    }
+}
+
 std::ostream &
 operator<<(std::ostream & out, const Configuration & configuration)
 {
@@ -102,6 +145,7 @@ operator<<(std::ostream & out, const Configuration & configuration)
     if (sentry)
     {
         out << "mode: " << configuration.mode << "\n";
+        out << "direction: " << configuration.direction << "\n";
         out << "endpoint: " << configuration.endpoint << "\n";
         out << "send_bandwidth: "
             << configuration.send_bandwidth << "/s\n";

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -111,7 +111,7 @@ operator>>(std::istream & in, Configuration::Direction & direction)
         else if (s == "both")
             direction = Configuration::BOTH;
         else
-            throw std::runtime_error("Unexpected verification mode");
+            throw std::runtime_error("Unexpected mode option value");
     }
 
     return in;

--- a/src/Configuration.hpp
+++ b/src/Configuration.hpp
@@ -39,10 +39,12 @@ struct Configuration
 {
     enum Mode { CLIENT, SERVER };
     enum Verify { NONE, FIRST, ALL };
+    enum Direction { RX, TX, BOTH };
     enum ShutdownPolicy { WAIT_FOR_PEER, SEND_COMPLETE, RECEIVE_COMPLETE };
 
     Mode mode;
     Verify verify;
+    Direction direction;
     std::string endpoint;
     Size send_bandwidth;
     Size receive_bandwidth;
@@ -61,6 +63,12 @@ operator<<(std::ostream & out, const Configuration::Verify & verify);
 
 std::ostream &
 operator<<(std::ostream & out, const Configuration::Mode & mode);
+
+std::istream &
+operator>>(std::istream & in, Configuration::Direction & direction);
+
+std::ostream &
+operator<<(std::ostream & out, const Configuration::Direction & direction);
 
 std::ostream &
 operator<<(std::ostream & out, const Configuration & configuration);

--- a/src/Executable.cpp
+++ b/src/Executable.cpp
@@ -95,7 +95,7 @@ parse_command_line(int argc, char** argv)
         ("duration-margin,d",
             po::value<pt::time_duration>(&c.duration_margin)
                 ->default_value(pt::not_a_date_time, "infinity"),
-            "Extra time from theorical test time allowed to"
+            "Extra time from theoretical test time allowed to"
             " complete without timeout error\n")
         ("help,h",
             "Print the command lines arguments\n");

--- a/src/Executable.cpp
+++ b/src/Executable.cpp
@@ -79,6 +79,11 @@ parse_command_line(int argc, char** argv)
                 ->default_value(Configuration::NONE),
             "Verify received bytes. Accepted values:\n"
             "  - none\n  - first\n  - all\n")
+        ("mode,m",
+            po::value<Configuration::Direction>(&c.direction)
+                ->default_value(Configuration::BOTH),
+            "Transfer mode. Accepted values:\n"
+            "  - rx\n  - tx\n  - both\n")
         ("windows,w",
             po::value<Size>(&c.windows),
             "Tcp socket buffer size (e.g. 8Kb, 16Mb)\n")

--- a/src/Executable.cpp
+++ b/src/Executable.cpp
@@ -122,6 +122,16 @@ parse_command_line(int argc, char** argv)
     if (! args.count("size") || args["size"].as<Size>() == 0)
         throw std::runtime_error("--size is required");
 
+    if (c.direction == Configuration::TX &&
+            c.shutdown_policy == Configuration::RECEIVE_COMPLETE)
+        throw std::runtime_error("TX mode isn't compatible with shutdown "
+                "policy receive_complete");
+
+    if (c.direction == Configuration::RX &&
+            c.shutdown_policy == Configuration::SEND_COMPLETE)
+        throw std::runtime_error("RX mode isn't compatible with shutdown "
+                "policy send_complete");
+
     if (args.count("connect"))
         c.mode = Configuration::CLIENT;
     else if (args.count("listen"))

--- a/src/MainLoop.cpp
+++ b/src/MainLoop.cpp
@@ -1,9 +1,0 @@
-#include "MainLoop.hpp"
-
-namespace enyx {
-namespace tcp_tester {
-
-
-} // namespace tcp_tester
-} // namespace enyx
-

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -38,7 +38,7 @@ namespace pt = boost::posix_time;
 namespace {
 
 std::string
-compute_bandwith(Size bytes_count,
+compute_bandwidth(Size bytes_count,
                  const pt::time_duration & duration)
 {
     std::ostringstream out;
@@ -62,13 +62,13 @@ operator<<(std::ostream & out, const Statistics & statistics)
     return out << "started: " << statistics.start_date << "\n"
                << "received_bytes_count: "
                << statistics.received_bytes_count << "\n"
-               << "receive_bandwith: "
-               << compute_bandwith(statistics.received_bytes_count,
+               << "receive_bandwidth: "
+               << compute_bandwidth(statistics.received_bytes_count,
                                    statistics.receive_duration) << "\n"
                << "sent_bytes_count: "
                << statistics.sent_bytes_count << "\n"
                << "send_bandwidth: "
-               << compute_bandwith(statistics.sent_bytes_count,
+               << compute_bandwidth(statistics.sent_bytes_count,
                                    statistics.total_duration)
                << std::endl;
 }


### PR DESCRIPTION
Adds support for the mode option, accepted values are `both` (normal mode), `tx` (the payload is just sent, not read back) and `rx` (the payload is just received and checked, not sent).
The support for the option is implemented in the first 3 patches.
The 3 following patches are just non-essential cosmetic changes.