### PR TITLE
Dump all sessions statistics after a failure

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -77,8 +77,16 @@ run(const ApplicationConfiguration & configuration)
     for (auto & thread : threads)
         thread.join();
 
-    for (auto & session : sessions)
-        session->finalize();
+    boost::system::error_code first_failure;
+    for (auto & session : sessions) {
+        boost::system::error_code failure = session->finalize();
+        if (failure && ! first_failure)
+            first_failure = failure;
+    }
+
+    if (first_failure)
+        throw boost::system::system_error(first_failure);
+
 }
 
 } // namespace Application

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -91,13 +91,13 @@ Session::on_init()
     });
 }
 
-void
+boost::system::error_code
 Session::finalize()
 {
     std::cout << statistics_ << std::endl;
+    std::cout << "status: " << failure_ << std::endl;
 
-    if (failure_)
-        throw boost::system::system_error(failure_);
+    return failure_;
 }
 
 pt::time_duration

--- a/src/Session.hpp
+++ b/src/Session.hpp
@@ -46,7 +46,7 @@ public:
     Session(boost::asio::io_service & io_service,
             const SessionConfiguration & configuration);
 
-    void
+    boost::system::error_code
     finalize();
 
 private:


### PR DESCRIPTION
Before this change, net-tester would stop displaying statistics after
the first session failure.

Signed-off-by: Denis Thulin <denis.thulin@enyx.fr>