### PR TITLE
Use shared_from_this in order to avoid segfault in io_service death

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -41,7 +41,7 @@ namespace ao = boost::asio;
 namespace pt = boost::posix_time;
 
 Session::Session(boost::asio::io_service & io_service,
-                        const SessionConfiguration & configuration)
+                 const SessionConfiguration & configuration)
     : io_service_(io_service),
       configuration_(configuration),
 #ifdef SIGHUP

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -41,7 +41,7 @@ namespace ao = boost::asio;
 namespace pt = boost::posix_time;
 
 Session::Session(boost::asio::io_service & io_service,
-                 const SessionConfiguration & configuration)
+                        const SessionConfiguration & configuration)
     : io_service_(io_service),
       configuration_(configuration),
 #ifdef SIGHUP
@@ -63,8 +63,14 @@ Session::Session(boost::asio::io_service & io_service,
       is_receive_complete_(),
       is_send_complete_()
 {
-    auto handler = [this] (const boost::system::error_code& error,
-                        int signal_number) {
+}
+
+void
+Session::initialize()
+{
+    auto self(shared_from_child());
+    auto handler = [this, self] (const boost::system::error_code& error,
+                            int signal_number) {
         if (error)
             // Signal unregistered
             return;
@@ -114,7 +120,8 @@ void
 Session::start_timer()
 {
     timeout_timer_.expires_from_now(estimate_test_duration(configuration_));
-    timeout_timer_.async_wait([this](boost::system::error_code const& failure) {
+    auto self(shared_from_child());
+    timeout_timer_.async_wait([this, self](boost::system::error_code const& failure) {
         if (failure)
             return;
 

--- a/src/Session.hpp
+++ b/src/Session.hpp
@@ -28,6 +28,7 @@
 #include <cstddef>
 #include <vector>
 #include <random>
+#include <memory>
 
 #include <boost/system/error_code.hpp>
 #include <boost/asio/deadline_timer.hpp>
@@ -47,16 +48,24 @@ public:
     Session(boost::asio::io_service & io_service,
             const SessionConfiguration & configuration);
 
+    virtual
+    void initialize();
+
     boost::system::error_code
     finalize();
 
 private:
     using buffer_type = std::vector<std::uint8_t>;
 
+
 protected:
     enum { BUFFER_SIZE = 128 << 10 };
 
 protected:
+
+    virtual std::shared_ptr<Session>
+    shared_from_child() = 0;
+
     virtual void
     async_receive(std::size_t slice_remaining_size = 0ULL) = 0;
 

--- a/src/Session.hpp
+++ b/src/Session.hpp
@@ -24,11 +24,11 @@
 
 #pragma once
 
-#include <cstdint>
 #include <cstddef>
-#include <vector>
-#include <random>
+#include <cstdint>
 #include <memory>
+#include <random>
+#include <vector>
 
 #include <boost/system/error_code.hpp>
 #include <boost/asio/deadline_timer.hpp>

--- a/src/TcpSession.hpp
+++ b/src/TcpSession.hpp
@@ -35,13 +35,28 @@
 namespace enyx {
 namespace net_tester {
 
-class TcpSession : public Session
+class TcpSession : public Session, public std::enable_shared_from_this<TcpSession>
 {
 public:
     TcpSession(boost::asio::io_service & io_service,
                const SessionConfiguration & configuration);
 
-private:
+    virtual void
+    initialize() override
+    {
+        auto self(shared_from_this());
+        socket_.open(configuration_, [this, self] { start_transfer(); });
+        io_service_.post([this, self] { start_timer(); } );
+    }
+
+protected:
+
+    virtual std::shared_ptr<Session>
+    shared_from_child() override
+    {
+        return shared_from_this();
+    }
+
     virtual void
     async_receive(std::size_t slice_remaining_size = 0ULL) override;
 

--- a/src/TcpSession.hpp
+++ b/src/TcpSession.hpp
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <cstddef>
+#include <memory>
 
 #include <boost/system/error_code.hpp>
 

--- a/src/TcpSession.hpp
+++ b/src/TcpSession.hpp
@@ -44,6 +44,7 @@ public:
     virtual void
     initialize() override
     {
+        Session::initialize();
         auto self(shared_from_this());
         socket_.open(configuration_, [this, self] { start_transfer(); });
         io_service_.post([this, self] { start_timer(); } );

--- a/src/TcpSocket.hpp
+++ b/src/TcpSocket.hpp
@@ -45,13 +45,17 @@ public:
     using protocol_type = socket_type::protocol_type;
 
 public:
-    template<typename OnConnectHandler>
     explicit
-    TcpSocket(boost::asio::io_service & io_service,
-              const SessionConfiguration & configuration,
-              OnConnectHandler on_connect)
+    TcpSocket(boost::asio::io_service & io_service)
         : Socket(io_service),
           socket_(io_service_)
+    {
+    }
+
+    template<typename OnConnectHandler>
+    void
+    open(const SessionConfiguration & configuration,
+         OnConnectHandler on_connect)
     {
         switch (configuration.mode)
         {
@@ -60,7 +64,7 @@ public:
                 connect(configuration, on_connect);
                 break;
             case SessionConfiguration::SERVER:
-                listen(configuration, io_service, on_connect);
+                listen(configuration, io_service_, on_connect);
                 break;
         }
     }

--- a/src/UdpSession.hpp
+++ b/src/UdpSession.hpp
@@ -33,13 +33,31 @@
 namespace enyx {
 namespace net_tester {
 
-class UdpSession : public Session
+class UdpSession : public Session, public std::enable_shared_from_this<UdpSession>
 {
 public:
     UdpSession(boost::asio::io_service & io_service,
                const SessionConfiguration & configuration);
 
-private:
+    virtual void
+    initialize() override
+    {
+        Session::initialize();
+        auto self(shared_from_this());
+        io_service_.post([this, self] {
+            start_timer();
+            start_transfer();
+        });
+    }
+
+protected:
+
+    virtual std::shared_ptr<Session>
+    shared_from_child() override
+    {
+        return shared_from_this();
+    }
+
     virtual void
     async_receive(std::size_t slice_remaining_size = 0ULL) override;
 

--- a/src/UdpSession.hpp
+++ b/src/UdpSession.hpp
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <cstddef>
+#include <memory>
 
 #include "Session.hpp"
 #include "UdpSocket.hpp"


### PR DESCRIPTION
As the io_service queue can only be cleared by destroying the io_service objects, it is necessary to keep a shared pointer to sessions in all callbacks that require the session.

Insipired by the [boost docs](https://live.boost.org/doc/libs/1_82_0/doc/html/boost_asio/reference/io_context/_io_context.html) and [examples](https://www.boost.org/doc/libs/1_83_0/doc/html/boost_asio/example/cpp11/http/server/connection.cpp).